### PR TITLE
Make navigation keys up and down repeatable

### DIFF
--- a/navigator.lua
+++ b/navigator.lua
@@ -118,8 +118,8 @@ end
 
 
 mp.add_key_binding("CTRL+f", "scandirectory", handler)
-mp.add_key_binding("CTRL+k", "navdown", navdown)
-mp.add_key_binding("CTRL+i", "navup", navup)
+mp.add_key_binding("CTRL+k", "navdown", navdown, "repeatable")
+mp.add_key_binding("CTRL+i", "navup", navup, "repeatable")
 mp.add_key_binding("CTRL+o", "opendir", opendir)
 mp.add_key_binding("CTRL+l", "childdirappend", childdirappend)
 mp.add_key_binding("CTRL+L", "childdirreplace", childdirreplace)


### PR DESCRIPTION
Adding keyword "repeatable" to input.conf doesn't have any effect.
After this change, these actions will be repeatable even if they are redefined in input.conf, e.g:
````
Ctrl+1 script-binding navigator/navdown
Ctrl+2 script-binding navigator/navup
````

Fixes #1 