### PR TITLE
replace space with non-breakable space in displayed file names

### DIFF
--- a/navigator.lua
+++ b/navigator.lua
@@ -104,12 +104,14 @@ function handler(arg)
   for a=b,(b+settings.osd_items_per_screen),1 do
     if a==length then break end
     if a == cursor then
-      output = output.."> "..dir[a].." <"
-      if arg == "added" then output = output.." + added to playlist\n"
-      elseif arg == "removed" then output = output.." - removed previous addition\n" else output=output.."\n" end
+      entry="> "..dir[a].." <"
+      if arg == "added" then entry = entry .." + added to playlist\n"
+      elseif arg == "removed" then entry = entry.." - removed previous addition\n" else entry=entry.."\n" end
     else
-      output = output..dir[a].."\n"
+      entry="  "..dir[a].."  \n"
     end
+    entry=string.gsub(entry, " ", "\160")
+    output = output..entry
     if a == (b+settings.osd_items_per_screen) then
       output=output.."..."
     end


### PR DESCRIPTION
this is useful for long names, as it avoids wrapping them to the next line

the file list also looks better IMO when using a monospace osd font, like in --osd-font=mono